### PR TITLE
chore: release 1.73.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ AppSec Platform][semgrep-platform], similar to `semgrep ci`, we provide the
 
 ```yaml
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'v1.72.0'
+  rev: 'v1.73.0'
   hooks:
     - id: semgrep-ci
 ```
@@ -29,7 +29,7 @@ committed with a specified config, skipping files with unknown extensions:
 
 ```yaml
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'v1.72.0'
+  rev: 'v1.73.0'
   hooks:
     - id: semgrep
       # See https://semgrep.dev/explore to select a ruleset and copy its URL

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="semgrep_pre_commit_package",
-    version="1.72.0",
-    install_requires=["semgrep==1.72.0"],
+    version="1.73.0",
+    install_requires=["semgrep==1.73.0"],
     packages=[],
 )


### PR DESCRIPTION
Releases 1.73.0. Requires tagging post-merge.