### PR TITLE
ci: sign commits in `bump_version` workflow [SEC-2166]

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -37,6 +37,7 @@ jobs:
           sign-commits: true
 
       - name: Tag release on bump branch
+        if: steps.cpr.outputs.pull-request-operation != 'none'
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           SHA: ${{ steps.cpr.outputs.pull-request-head-sha }}

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -13,7 +13,7 @@ jobs:
         name: Get token for semgrep-ci GitHub App
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.SEMGREP_CI_CLIENT_ID }}
+          client-id: ${{ secrets.SEMGREP_CI_CLIENT_ID }}
           private-key: ${{ secrets.SEMGREP_CI_APP_KEY }}
           repositories: pre-commit
 

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     env:
-      NEW_SEMGREP_VERSION: ${{ github.event.inputs.version }}
+      NEW_SEMGREP_VERSION: ${{ inputs.version }}
     steps:
       - id: token
         name: Get token for semgrep-ci GitHub App
@@ -17,49 +17,33 @@ jobs:
           private-key: ${{ secrets.SEMGREP_CI_APP_KEY }}
           repositories: pre-commit
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          token: ${{ steps.token.outputs.token }}
+          persist-credentials: false
 
       - name: Bump version in this repo
         run: scripts/bump-version.sh "${NEW_SEMGREP_VERSION}"
 
-      - name: Commit and push
-        id: commit
-        env:
-          BRANCH: "gha/bump-version-${{ github.event.inputs.version }}-${{ github.run_id }}-${{ github.run_attempt }}"
-          SUBJECT: "Bump setup to ${{ github.event.inputs.version }}"
-        run: |
-          git config user.name ${{ github.actor }}
-          git config user.email ${{ github.actor }}@users.noreply.github.com
-          git checkout -b $BRANCH
-          git commit -am "$SUBJECT"
-          git tag "v${NEW_SEMGREP_VERSION}" HEAD
-          git remote -vv
-          git push --set-upstream origin $BRANCH
-          git push origin tag "v$NEW_SEMGREP_VERSION"
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-          echo "subject=$SUBJECT" >> $GITHUB_OUTPUT
+      - name: Open bump-version PR
+        id: cpr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.token.outputs.token }}
+          branch: "gha/bump-version-${{ inputs.version }}-${{ github.run_id }}-${{ github.run_attempt }}"
+          base: ${{ github.event.repository.default_branch }}
+          title: "chore: update pre-commit to semgrep ${{ inputs.version }}"
+          body: "Bump Semgrep Version to ${{ inputs.version }}"
+          commit-message: "Bump setup to ${{ inputs.version }}"
+          sign-commits: true
 
-      - name: Create PR
-        id: open-pr
+      - name: Tag release on bump branch
         env:
-          SOURCE: "${{ steps.commit.outputs.branch }}"
-          TARGET: "${{ github.event.repository.default_branch }}"
-          TITLE: "chore: update pre-commit to semgrep ${{ inputs.version }}"
-          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
-          VERSION: "${{ inputs.version }}"
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          SHA: ${{ steps.cpr.outputs.pull-request-head-sha }}
         run: |
-          # check if the branch already has a pull request open
-          if gh pr list --head ${SOURCE} | grep -vq "no pull requests"; then
-              # pull request already open
-              echo "pull request from SOURCE ${SOURCE} to TARGET ${TARGET} is already open";
-              echo "cancelling release"
-              exit 1
-          fi
-          # open new pull request with the body of from the local template.
-          res=$(gh pr create --title "${TITLE}" --body "Bump Semgrep Version to ${VERSION}" \
-            --base "${TARGET}" --head "${SOURCE}")
+          gh api -X POST "repos/${{ github.repository }}/git/refs" \
+            -f ref="refs/tags/v${NEW_SEMGREP_VERSION}" \
+            -f sha="${SHA}"
 
 name: bump-version
 on:

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -5,32 +5,17 @@
 jobs:
   bump-version:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
-      pull-requests: write
-      checks: write
+    permissions: {}
     env:
       NEW_SEMGREP_VERSION: ${{ github.event.inputs.version }}
     steps:
-      - id: jwt
-        env:
-          EXPIRATION: 600
-          ISSUER: ${{ secrets.SEMGREP_CI_APP_ID }}
-          PRIVATE_KEY: ${{ secrets.SEMGREP_CI_APP_KEY }}
-        name: Get JWT for semgrep-ci GitHub App
-        uses: docker://public.ecr.aws/y9k7q4m1/devops/cicd:latest
-
       - id: token
         name: Get token for semgrep-ci GitHub App
-        run: |
-          TOKEN="$(curl -X POST \
-          -H "Authorization: Bearer ${{ steps.jwt.outputs.jwt }}" \
-          -H "Accept: application/vnd.github.v3+json" \
-          "https://api.github.com/app/installations/${{ secrets.SEMGREP_CI_APP_INSTALLATION_ID }}/access_tokens" | \
-          jq -r .token)"
-          echo "::add-mask::$TOKEN"
-          echo "token=$TOKEN" >> $GITHUB_OUTPUT
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.SEMGREP_CI_CLIENT_ID }}
+          private-key: ${{ secrets.SEMGREP_CI_APP_KEY }}
+          repositories: pre-commit
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Makes the `bump_version` workflow produce signed commits

- **Sign the bump commit.** Replace local `git commit -am` (unsigned, the cause of the "Require Signed Commits" Fails in Rule Insights) with `peter-evans/create-pull-request@v8.1.1`
- **Collapse PR creation.** peter-evans handles opening the PR, so the manual `gh pr create` step and the unreachable `gh pr list | grep` "PR exists" guard are gone.
- **Tag via API.** Switch tag creation to `gh api .../git/refs` against `pull-request-head-sha` from peter-evans, since local HEAD doesn't advance after an API commit. Result is the same lightweight tag as before.
- **Modernize token minting.** Replace the bespoke JWT + curl block with `actions/create-github-app-token@v3.1.1`
- **Drop unused permissions.** `permissions: {}` since the workflow no longer touches `secrets.GITHUB_TOKEN`.

## Testing

[This run](https://github.com/semgrep/pre-commit/actions/runs/25579031041/job/75093207059) successfully opened [this PR](https://github.com/semgrep/pre-commit/pull/117/changes). Tagging correctly skipped for existing version on [this run](https://github.com/semgrep/pre-commit/actions/runs/25579740763/job/75095570261).

🤖 Generated with [Claude Code](https://claude.com/claude-code)